### PR TITLE
Download prism `tmean` and `ppt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ vignettes/*.pdf
 gd_config.yml
 _targets/*
 1_download/out/*
+1_download/prism_data/*
 !*/*/.placeholder
 

--- a/1_download.R
+++ b/1_download.R
@@ -38,6 +38,45 @@ p1_download <- list(
       overwrite = TRUE)
     return(files_saved_info$local_path)
   }, format = 'file',
-  pattern = map(p1_gd_netcdfs))
+  pattern = map(p1_gd_netcdfs)),
+  
+  ##### Download the GEE imagery mission-dates from Google Drive #####
+  
+  # List the files available in this specified folder
+  tar_target(p1_gd_id_missiondates, as_id('1UEEVBlvX7P4H2dtNoX1oj44-Xeyg6x01')),
+  tar_target(p1_gd_missiondates_csv, {
+    # Add a dependency on p1_authenticated_user target so that this 
+    # builds AFTER the target for authenticated to GH has been run.
+    message(sprintf('Attempting to download a file using permissions for %s', 
+                    p1_authenticated_user$emailAddress))
+    gd_file_info <- drive_get(p1_gd_id_missiondates)
+    local_file_info <- drive_download(
+      p1_gd_id_missiondates,
+      path = sprintf('1_download/out/%s', gd_file_info$name),
+      overwrite=TRUE)
+    return(local_file_info$local_path)
+  }, format = "file"),
 
+  ##### Download the PRISM meteo data #####
+  
+  tar_target(p1_prism_vars, c('tmean', 'ppt')),
+  
+  tar_target(p1_prism_files, {
+    # Download each date for the current variable from PRISM
+    dir_out <- '1_download/prism_data'
+    prism_set_dl_dir(dir_out)
+    get_prism_dailys(
+      type = p1_prism_vars,
+      dates = p2_prism_dates[year(p2_prism_dates) >= 2022],
+      keepZip=FALSE
+    )
+    # In order to track files and changes, list the files saved in
+    # the folder as the output here. This works since each subfolder
+    # is named with the variable and date so adding dates or vars
+    # will result in changes here. 
+    var_files <- list.files(dir_out, pattern = p1_prism_vars)
+    return(tibble(prism_var = p1_prism_vars,
+                  prism_files = var_files))
+  }, pattern = map(p1_prism_vars))
+  
 )

--- a/1_download.R
+++ b/1_download.R
@@ -115,6 +115,12 @@ p1_download <- list(
     return(tibble(prism_var = p1_prism_vars,
                   prism_files = var_files))
   }, 
-  pattern = cross(p1_prism_vars, p1_prism_download_batches))
+  pattern = cross(p1_prism_vars, p1_prism_download_batches),
+  # Sometimes there is a temporary timeout when pulling a date. Retrying 
+  # has usually fixed it. To handle this more automatically, use `error="null"`
+  # so that this target will move on and build all branches BUT will
+  # not considered "complete" and thus will try to rebuild the branch that
+  # errored the next time the pipeline is built.
+  error = "null")
   
 )

--- a/1_download.R
+++ b/1_download.R
@@ -96,7 +96,7 @@ p1_download <- list(
     # Download each date for the current variable from PRISM
     get_prism_dailys(
       type = p1_prism_vars,
-      dates = p2_prism_dates[year(p2_prism_dates) >= 2022],
+      dates = p2_prism_dates,
       keepZip=FALSE
     )
     # In order to track files and changes, list the files saved in

--- a/2_process.R
+++ b/2_process.R
@@ -71,9 +71,11 @@ p2_process <- list(
       lat = p1_lake_superior_grid_centers$latitude,
       lon = p1_lake_superior_grid_centers$longitude,
       prism_var = p1_prism_vars,
+      prism_dates = p1_prism_download_batches$date,
       prism_dir = p1_prism_dir)
   }, 
-  pattern = cross(p1_lake_superior_grid_centers, p1_prism_vars),
+  pattern = cross(p1_lake_superior_grid_centers, p1_prism_vars,
+                  p1_prism_download_batches),
   iteration = "list"),
   
   # Convert the `prism` plot objects into a single data frame

--- a/2_process.R
+++ b/2_process.R
@@ -53,6 +53,28 @@ p2_process <- list(
     purrr::map(p2_mission_dates_aprnov, function(date) {
       seq(from = date - 14, to = date, by = "days")
     }) %>% reduce(c) %>% unique()
-  })
+  }),
+  
+  ##### Read PRISM files and load into tibbles #####
+  
+  # TODO: some grid cells return NAs because the centroid is over 
+  # the water (and I assume there is some sort of water masking?)
+  # Also, need to see grid cell size compared to PRISM resolution
+  # because some seem like they are duplicates.
+  
+  # For a given lat/long, use `prism` fxns to extract timeseries
+  tar_target(p2_prism_plots, 
+             extract_prism_at_location(
+               lat = p1_lake_superior_grid_centers$latitude,
+               lon = p1_lake_superior_grid_centers$longitude,
+               prism_var = p1_prism_vars,
+               prism_dir = p1_prism_dir), 
+             pattern = cross(p1_lake_superior_grid_centers, p1_prism_vars),
+             iteration = "list"),
+  
+  # Convert the `prism` plot objects into a single data frame
+  # with all PRISM vars
+  tar_target(p2_prism_data, p2_prism_plots$data, 
+             pattern = map(p2_prism_plots))
   
 )

--- a/2_process.R
+++ b/2_process.R
@@ -63,14 +63,18 @@ p2_process <- list(
   # because some seem like they are duplicates.
   
   # For a given lat/long, use `prism` fxns to extract timeseries
-  tar_target(p2_prism_plots, 
-             extract_prism_at_location(
-               lat = p1_lake_superior_grid_centers$latitude,
-               lon = p1_lake_superior_grid_centers$longitude,
-               prism_var = p1_prism_vars,
-               prism_dir = p1_prism_dir), 
-             pattern = cross(p1_lake_superior_grid_centers, p1_prism_vars),
-             iteration = "list"),
+  tar_target(p2_prism_plots, {
+    # Make this target dependent on the prism files so that it will
+    # if they change.
+    p1_prism_files
+    extract_prism_at_location(
+      lat = p1_lake_superior_grid_centers$latitude,
+      lon = p1_lake_superior_grid_centers$longitude,
+      prism_var = p1_prism_vars,
+      prism_dir = p1_prism_dir)
+  }, 
+  pattern = cross(p1_lake_superior_grid_centers, p1_prism_vars),
+  iteration = "list"),
   
   # Convert the `prism` plot objects into a single data frame
   # with all PRISM vars

--- a/2_process/src/process_helpers.R
+++ b/2_process/src/process_helpers.R
@@ -33,13 +33,13 @@ summarize_raster_class_counts <- function(raster_list) {
     select(mission, date, class = value, count)
 }
 
-extract_prism_at_location <- function(lat, lon, prism_var, prism_dir) {
+extract_prism_at_location <- function(lat, lon, prism_var, prism_dates, prism_dir) {
   
   # Set the prism archive location
   prism_set_dl_dir(prism_dir)
   
   # Use prism helper fxns to list relevant files for the variable
-  to_slice <- prism_archive_subset(prism_var, "daily")
+  to_slice <- prism_archive_subset(prism_var, "daily", dates = prism_dates)
   
   # Convert sf point to a vector, `c(longitude, latitude)`
   lon_lat_vector <- c(lon, lat)

--- a/2_process/src/process_helpers.R
+++ b/2_process/src/process_helpers.R
@@ -32,3 +32,29 @@ summarize_raster_class_counts <- function(raster_list) {
            date = raster_list$date) %>% 
     select(mission, date, class = value, count)
 }
+
+extract_prism_at_location <- function(lat, lon, prism_var, prism_dir) {
+  
+  # Set the prism archive location
+  prism_set_dl_dir(prism_dir)
+  
+  # Use prism helper fxns to list relevant files for the variable
+  to_slice <- prism_archive_subset(prism_var, "daily")
+  
+  # Convert sf point to a vector, `c(longitude, latitude)`
+  lon_lat_vector <- c(lon, lat)
+  # NAs result unless I round to only 1 decimal
+  # round(digits=1)
+  
+  # User prism helper function to slice the files into a plot obj
+  var_pd_plot <- pd_plot_slice(to_slice, lon_lat_vector)
+  
+  # Add a column to the time series data 
+  var_pd_plot$data <- var_pd_plot$data %>% 
+    mutate(var = prism_var,
+           longitude = lon,
+           latitude = lat) %>% 
+    select(longitude, latitude, variable = var, date, value = data)
+  
+  return(var_pd_plot)
+}

--- a/4_visualize.R
+++ b/4_visualize.R
@@ -22,12 +22,15 @@ p4_visualize <- list(
   tar_target(p4_prism_summary, {
     p2_prism_data %>% 
       left_join(p1_lake_superior_grid_centers) %>% 
+      # These cells all have NA (assuming that these
+      # are NA because the centroids are over water)
+      filter(!cell_no %in% c(4, 6, 8, 11, 12)) %>% 
       ggplot(aes(x = date, y = value, 
                  color = cell_no)) + 
       geom_point() +
       scico::scale_color_scico(begin = 0.15, end = 0.85,
                                palette = "batlow") +
-      facet_grid(cell_no ~ variable)
+      facet_grid(cell_no ~ variable, scales = 'free')
   })
   
 )

--- a/4_visualize.R
+++ b/4_visualize.R
@@ -17,6 +17,17 @@ p4_visualize <- list(
         breaks = bloom_plume_class_xwalk$val,
         labels = bloom_plume_class_xwalk$nm) +
       ylab('Pixel count') + xlab('Year')
+  }),
+  
+  tar_target(p4_prism_summary, {
+    p2_prism_data %>% 
+      left_join(p1_lake_superior_grid_centers) %>% 
+      ggplot(aes(x = date, y = value, 
+                 color = cell_no)) + 
+      geom_point() +
+      scico::scale_color_scico(begin = 0.15, end = 0.85,
+                               palette = "batlow") +
+      facet_grid(cell_no ~ variable)
   })
   
 )

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ At this time, the raster files are kept in a Google Drive folder where you need 
 After you build the pipeline, you should be able to see the following:
 
 1. Histogram summarizing the pixel counts by year and mission: `tar_read(p4_basic_summary_histogram)`
+2. PRISM drivers as timeseries, visualized by location: `tar_read(p4_prism_summary)`
 
 ## Contributing to this pipeline
 

--- a/_targets.R
+++ b/_targets.R
@@ -10,6 +10,7 @@ tar_option_set(packages = c(
   'ncdf4',
   'prism',
   'raster',
+  'sf',
   'tidyverse',
   'yaml'
 ), format='qs')

--- a/_targets.R
+++ b/_targets.R
@@ -8,6 +8,7 @@ options(googledrive_quiet = TRUE)
 tar_option_set(packages = c(
   'googledrive',
   'ncdf4',
+  'prism',
   'raster',
   'tidyverse',
   'yaml'


### PR DESCRIPTION
This code downloads PRISM data for vars `tmean` and `ppt` based on the mission-dates provided over in [Superior-Plume-Bloom](https://github.com/rossyndicate/Superior-Plume-Bloom/blob/main/eePlumB/B_process_LS_mission-date/2_processMissionDateList.Rmd). It uses the mission dates as the anchors and also downloads the preceding 2 weeks of driver data for each. 

I used the [`rOpenSci/prism` package](https://docs.ropensci.org/prism/reference/prism-package.html). to download and extract the PRISM data. This seemed easiest in terms of coding, though it downloads EVERYTHING in space for your specified date/variable. You later subset to get the summary at specific lat/longs, but the download part takes forever (~10 hrs) because of how that is organized. 

In the end the PRISM data are loaded for the centroids of each of the grid cells (based on [this in Superior-Plume-Bloom](https://github.com/rossyndicate/Superior-Plume-Bloom/blob/efa1bdc644611ee97c2e1e0c3bf0cfc4a7ca1955/eePlumB/A_PrepAOI/TileAOI.Rmd#L31-L52)) and saved as a big timeseries data frame, `p2_prism_data`. I also plotted these in `p4_prism_summary`. Some of the grid cells show NA and I am assuming it is because their centroids are over water and there is a water mask in this dataset. 

Here is what the data look like per cell (minus the NA cells):

```r
targets::tar_read(p4_prism_summary)
```

![image](https://user-images.githubusercontent.com/13220910/233193392-5acd1021-e976-4401-9537-5a0508db1930.png)
