### PR TITLE
Pull all prism dates

### DIFF
--- a/1_download.R
+++ b/1_download.R
@@ -125,4 +125,10 @@ p1_download <- list(
   # errored the next time the pipeline is built.
   error = "null")
   
+  # If you download the zip of all the pre-downloaded prism data, uncomment
+  # this target and comment out the one above instead. Make sure you 
+  # unzip the files and place them in `1_download/prism_data/`
+  # tar_target(p1_prism_files, 
+  #            list.files('1_download/prism_data'))
+  
 )

--- a/1_download.R
+++ b/1_download.R
@@ -88,12 +88,14 @@ p1_download <- list(
   
   tar_target(p1_prism_dir, '1_download/prism_data'),
   tar_target(p1_prism_vars, c('tmean', 'ppt')),
+  tar_target(p1_prism_dates, seq(from = as.Date("1981-01-01"), 
+                                 to = as.Date("2022-09-30"), by = "days")),
   
   # Group the dates so that we can query individually and
   # therefore rebuild only dates that don't work, but not
   # store thousands of dynamic branches
   tar_group_count(p1_prism_download_batches, 
-                  tibble(date = p2_prism_dates),
+                  tibble(date = p1_prism_dates),
                   count = 20),
   
   tar_target(p1_prism_files, {

--- a/2_process.R
+++ b/2_process.R
@@ -47,13 +47,6 @@ p2_process <- list(
                unique() %>% 
                # Sort is needed because B randomized the mission-dates for eePlumb workflow
                sort()),
-  tar_target(p2_prism_dates, {
-    # Create vector of dates for which to download PRISM data. Only want 
-    # to download the mission dates and 2 preceding weeks
-    purrr::map(p2_mission_dates_aprnov, function(date) {
-      seq(from = date - 14, to = date, by = "days")
-    }) %>% reduce(c) %>% unique()
-  }),
   
   ##### Read PRISM files and load into tibbles #####
   

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Using classified raster images and meteo drivers to try to better understand wha
 
 This pipeline is setup to download, process, and run models for detecting blooms and plumes. It is structured as a [`{{targets}}`](https://docs.ropensci.org/targets/) pipeline so that the workflow is easily reproducible and can be followed. The pipeline and workflow be run easily using `tar_make()`. The first time you run this, you may get errors about missing packages. Install those and then try again.
 
-At this time, the raster files are kept in a Google Drive folder where you need to have specific access. The data may be released in the future, which would make this step easier. For now, you need to follow the steps below in order to authenticate to Google Drive when running `tar_make()`.
+The meteorological driver data from Prism does take a long time to download. If you have access to the zip file of these pre-downloaded data on Box, comment out the `p1_prism_files` target in `1_download.R` and uncomment the target with the same name that is set up below it. You will need to download the zip file from Box and unzip the files to the `1_download/prism_data/` directory before being able to build the full pipeline.
+
+At this time, the raster files of classified imagery are kept in a Google Drive folder where you need to have specific access. The data may be released in the future, which would make this step easier. For now, you need to follow the steps below in order to authenticate to Google Drive when running `tar_make()`.
 
 1. Create a new text file called `.gd_config` and save in the top-level directory of this project.
 2. Copy-paste this code into that file: `gd_email: 'YOUR_EMAIL@some.service'`


### PR DESCRIPTION
Fixes #4. Adjusted to pull all the dates between `1981-01-01` and `2022-09-30`. According to their website, it takes 6 months to get the new dates in [their "Recent years" service](https://prism.oregonstate.edu/recent/), but if we want `2022-10-01` and onward, we could manually pull [the "Prior 6 months"](https://prism.oregonstate.edu/6month/) and combine with the others. 

Since this takes so long to download (multiple days!), I zipped up the `prism_data` folder and uploaded to Box. Those with access can follow the instructions in the README to use the zip file and skip downloading from the service themselves. The resulting `p2_prism_data` dataset has 365k rows based on how the 12 grid cells we are currently set up to use (note that this will change with #5). Please note that even with this zipfile to bypass the download, the pipeline will still take a few hours to build (`p2_prism_plots` takes 1.5 hrs alone :smile:)

```r
targets::tar_read(p4_prism_summary)
```

![image](https://user-images.githubusercontent.com/13220910/233810738-4d22bf00-8c27-410f-a978-a7e09be20f6e.png)
 