### PR TITLE
Add observed bloom data from Kait's spreadsheet

### DIFF
--- a/1_download.R
+++ b/1_download.R
@@ -57,6 +57,8 @@ p1_download <- list(
     return(local_file_info$local_path)
   }, format = "file"),
   
+  ##### Load spatial data for Lake Superior watershed & AOI #####
+  
   tar_target(p1_lake_superior_box_sf, {
     # Pulled the bounding box for our Lake Superior AOI:
     # https://github.com/rossyndicate/Superior-Plume-Bloom/blob/efa1bdc644611ee97c2e1e0c3bf0cfc4a7ca1955/eePlumB/A_PrepAOI/TileAOI.Rmd#L31-L52
@@ -84,8 +86,6 @@ p1_download <- list(
       setNames(c('longitude', 'latitude')) %>% 
       mutate(cell_no = row_number())),
 
-  ##### Read in the Lake Superior watershed shapes #####
-  
   tar_target(p1_lake_superior_watershed_shp, '1_download/in/LakeSuperiorWatershed.shp', format="file"),
   tar_target(p1_lake_superior_watershed_sf, st_read(p1_lake_superior_watershed_shp)),
   

--- a/1_download.R
+++ b/1_download.R
@@ -57,7 +57,7 @@ p1_download <- list(
     return(local_file_info$local_path)
   }, format = "file"),
   
-  tar_target(p1_lake_superior_sf, {
+  tar_target(p1_lake_superior_box_sf, {
     # Pulled the bounding box for our Lake Superior AOI:
     # https://github.com/rossyndicate/Superior-Plume-Bloom/blob/efa1bdc644611ee97c2e1e0c3bf0cfc4a7ca1955/eePlumB/A_PrepAOI/TileAOI.Rmd#L31-L52
     sup_box <- tibble(ymin = 46.5, ymax = 47.3,  xmin = -92.2,xmax = -90.1)
@@ -71,7 +71,7 @@ p1_download <- list(
   tar_target(p1_lake_superior_grid_sf, 
     # Now make the grid using that box. To do this, I borrowed code from:
     # https://github.com/rossyndicate/Superior-Plume-Bloom/blob/efa1bdc644611ee97c2e1e0c3bf0cfc4a7ca1955/eePlumB/A_PrepAOI/TileAOI.Rmd#L31-L52
-    st_make_grid(p1_lake_superior_sf, 
+    st_make_grid(p1_lake_superior_box_sf, 
                  cellsize = c(0.55, 0.3)) # units are degrees
   ),
     

--- a/1_download.R
+++ b/1_download.R
@@ -40,22 +40,18 @@ p1_download <- list(
   }, format = 'file',
   pattern = map(p1_gd_netcdfs)),
   
-  ##### Download the GEE imagery and AOI mission-dates from Google Drive #####
-  
-  # List the files available in this specified folder
-  tar_target(p1_gd_id_missiondates, as_id('1UEEVBlvX7P4H2dtNoX1oj44-Xeyg6x01')),
-  tar_target(p1_gd_missiondates_csv, {
+  # Download the observed blooms dataset
+  tar_target(p1_obs_blooms_xlsx, {
     # Add a dependency on p1_authenticated_user target so that this 
     # builds AFTER the target for authenticated to GH has been run.
-    message(sprintf('Attempting to download a file using permissions for %s', 
-                    p1_authenticated_user$emailAddress))
-    gd_file_info <- drive_get(p1_gd_id_missiondates)
-    local_file_info <- drive_download(
-      p1_gd_id_missiondates,
-      path = sprintf('1_download/out/%s', gd_file_info$name),
-      overwrite=TRUE)
-    return(local_file_info$local_path)
-  }, format = "file"),
+    p1_authenticated_user
+    
+    files_saved_info <- drive_download(
+      as_id('1JPheDfzusaOWRS4Dew9KTnCRAqJSQykV'), 
+      path = '1_download/out/lake_sup_bloom_history.xlsx',
+      overwrite = TRUE)
+    return(files_saved_info$local_path)
+  }, format = 'file'),
   
   ##### Load spatial data for Lake Superior watershed & AOI #####
   

--- a/1_download.R
+++ b/1_download.R
@@ -41,13 +41,21 @@ p1_download <- list(
   pattern = map(p1_gd_netcdfs)),
   
   # Download the observed blooms dataset
+  tar_target(p1_gd_id_obs_blooms, as_id('1JPheDfzusaOWRS4Dew9KTnCRAqJSQykV')),
+  tar_target(p1_obs_blooms_gd_hash, drive_get(p1_gd_id_obs_blooms) %>% 
+               pluck('drive_resource', 1, 'md5Checksum'),
+             # Always ping GD and get the hash of this file in case it changes
+             cue = tar_cue('always')),
   tar_target(p1_obs_blooms_xlsx, {
     # Add a dependency on p1_authenticated_user target so that this 
-    # builds AFTER the target for authenticated to GH has been run.
+    # builds AFTER the target for authenticated to GD has been run.
     p1_authenticated_user
     
+    # Depend on the file hash so that this rebuilds if the GD file changes
+    p1_obs_blooms_gd_hash
+    
     files_saved_info <- drive_download(
-      as_id('1JPheDfzusaOWRS4Dew9KTnCRAqJSQykV'), 
+      p1_gd_id_obs_blooms, 
       path = '1_download/out/lake_sup_bloom_history.xlsx',
       overwrite = TRUE)
     return(files_saved_info$local_path)

--- a/2_process.R
+++ b/2_process.R
@@ -34,6 +34,10 @@ p2_process <- list(
              # Landsat 7 striping issue.
   ),
   
+  ##### Load and process observed blooms spreadsheet #####
+  
+  tar_target(p2_obs_blooms, clean_bloom_history(p1_obs_blooms_xlsx)),
+  
   ##### Read PRISM files and load into tibbles #####
   
   # TODO: some grid cells return NAs because the centroid is over 

--- a/2_process.R
+++ b/2_process.R
@@ -36,7 +36,16 @@ p2_process <- list(
   
   ##### Load and process observed blooms spreadsheet #####
   
-  tar_target(p2_obs_blooms, clean_bloom_history(p1_obs_blooms_xlsx)),
+  tar_target(p2_obs_blooms_details, clean_bloom_history(p1_obs_blooms_xlsx)),
+  tar_target(p2_obs_blooms_sf, {
+    p2_obs_blooms_details %>% 
+      select(Year, `Start Date`, `End Date`, Latitude, Longitude, Verified_cyanos) %>% 
+      st_as_sf(coords = c('Longitude', 'Latitude'), crs=4326) %>% 
+      # Remove observations outside of our AOI
+      st_crop(p1_lake_superior_box_sf) %>% 
+      # Transform to match other sf object projections
+      st_transform(crs = st_crs(p1_lake_superior_watershed_sf))
+  }),
   
   ##### Read PRISM files and load into tibbles #####
   

--- a/2_process.R
+++ b/2_process.R
@@ -34,20 +34,6 @@ p2_process <- list(
              # Landsat 7 striping issue.
   ),
   
-  ##### Process GEE mission-dates to prepare for PRISM query #####
-  
-  tar_target(p2_mission_dates_aprnov, 
-             read_csv(p1_gd_missiondates_csv) %>% 
-               # Keep only dates between April and November, as B does here:
-               # https://github.com/rossyndicate/Superior-Plume-Bloom/blob/main/eePlumB/B_process_LS_mission-date/2_processMissionDateList.Rmd#L48-L55
-               mutate(month = lubridate::month(DATE_ACQUIRED)) %>% 
-               filter(month >=4, month <= 11) %>% 
-               pull(DATE_ACQUIRED) %>% 
-               # Only need the unique dates, not duplicates per mission
-               unique() %>% 
-               # Sort is needed because B randomized the mission-dates for eePlumb workflow
-               sort()),
-  
   ##### Read PRISM files and load into tibbles #####
   
   # TODO: some grid cells return NAs because the centroid is over 

--- a/2_process.R
+++ b/2_process.R
@@ -56,12 +56,12 @@ p2_process <- list(
   # because some seem like they are duplicates.
   tar_target(p2_lake_superior_watershed_filt, {
     # Transform Lake Superior grid shape before using in filter
-    p1_lake_superior_sf_transf <- p1_lake_superior_sf %>% 
+    p1_lake_superior_box_sf_transf <- p1_lake_superior_box_sf %>% 
       st_transform(crs = st_crs(p1_lake_superior_watershed_sf))
     
     # Filter to only subwatersheds within 5 miles of the AOI bbox
     p1_lake_superior_watershed_sf %>%
-      st_filter(p1_lake_superior_sf_transf, 
+      st_filter(p1_lake_superior_box_sf_transf, 
                 .predicate = st_is_within_distance, 
                 dist = 1609*5)
   }),

--- a/2_process/src/process_helpers.R
+++ b/2_process/src/process_helpers.R
@@ -54,7 +54,9 @@ clean_bloom_history <- function(file_in) {
     # Rather than reformat the Year column, just delete and
     # add back using the `Start Date` column
     select(-Year) %>% 
-    mutate(Year = year(`Start Date`), .before = `Start Date`)
+    mutate(Year = year(`Start Date`), .before = `Start Date`) %>% 
+    # Remove any data that doesn't have a location listed
+    filter(!is.na(Longitude), !is.na(Latitude)) 
   
   return(obs_blooms_clean)
 }

--- a/2_process/src/process_helpers.R
+++ b/2_process/src/process_helpers.R
@@ -56,7 +56,10 @@ clean_bloom_history <- function(file_in) {
     select(-Year) %>% 
     mutate(Year = year(`Start Date`), .before = `Start Date`) %>% 
     # Remove any data that doesn't have a location listed
-    filter(!is.na(Longitude), !is.na(Latitude)) 
+    filter(!is.na(Longitude), !is.na(Latitude)) %>% 
+    # Harmonize the 'verified' column - just leave T/F for whether it was verified or not (NA = FALSE)
+    mutate(Verified_cyanos = grepl('^(v|V)erified', `Verified cyanos with microscope?`), 
+           .after = `Water Body Name`)
   
   return(obs_blooms_clean)
 }

--- a/2_process/src/process_helpers.R
+++ b/2_process/src/process_helpers.R
@@ -33,6 +33,32 @@ summarize_raster_class_counts <- function(raster_list) {
     select(mission, date, class = value, count)
 }
 
+# Read in and process the manually generated bloom observation spreadsheet from Kait Reinl
+clean_bloom_history <- function(file_in) {
+  
+  # Initially load the excel spreadsheet in order to get columns to use after 
+  # skipping first two data rows (row 1 = header above column names, skip it)
+  obs_blooms_raw <- read_excel(file_in, skip = 1, sheet = 'BloomHistory')
+  
+  # Read without the 'circa' observations from 1968 & 1995 (random header + 
+  # col names row + the two old observations = 4 to skip)
+  obs_blooms_clean <- read_excel(file_in, 
+                           skip = 4, sheet = 'BloomHistory',
+                           col_names = names(obs_blooms_raw),
+                           na = "n/a") %>% 
+    # Remove spaces and headers between the secondary tables 
+    filter(!is.na(Year),
+           !Year %in% c("Inland lake reports", 
+                        "Benthic bloom reports",
+                        "Green water (no surface scum)")) %>% 
+    # Rather than reformat the Year column, just delete and
+    # add back using the `Start Date` column
+    select(-Year) %>% 
+    mutate(Year = year(`Start Date`), .before = `Start Date`)
+  
+  return(obs_blooms_clean)
+}
+
 # Convert the `prism` plot objects into a single data frame, including the HUC info
 get_prism_data_at_huc_centers <- function(huc_latlong_table, prism_var, prism_dates, prism_dir) {
   

--- a/4_visualize.R
+++ b/4_visualize.R
@@ -3,6 +3,8 @@ p4_visualize <- list(
   
   tar_target(p4_basic_summary_histogram, {
     
+    ##### Classified GEE output figures #####
+    
     # Prepare a vector to use for colors
     color_vec <- bloom_plume_class_xwalk$color
     names(color_vec) <- bloom_plume_class_xwalk$val
@@ -18,6 +20,18 @@ p4_visualize <- list(
         labels = bloom_plume_class_xwalk$nm) +
       ylab('Pixel count') + xlab('Year')
   }),
+  
+  ##### Observed blooms figures #####
+  
+  tar_target(p4_obs_blooms_map, {
+    ggplot() +
+      geom_sf(data = st_simplify(p2_lake_superior_watershed_filt, dTolerance = 100),
+              fill = '#c4dbbc', color = 'white') +
+      geom_sf(data = p2_obs_blooms_sf, aes(color = Year, shape = Verified_cyanos)) +
+      theme_void() + ggtitle('Observed bloom locations in our defined AOI')
+  }),
+  
+  ##### PRISM climate driver summary figures #####
   
   tar_target(p4_prism_summary_timeseries, {
     p2_prism_data_huc %>% 

--- a/4_visualize.R
+++ b/4_visualize.R
@@ -31,6 +31,16 @@ p4_visualize <- list(
       theme_void() + ggtitle('Observed bloom locations in our defined AOI')
   }),
   
+  tar_target(p4_obs_blooms_timeseries, {
+    ggplot(p2_obs_blooms_details, aes(x = `Start Date`, 
+                                      y = Verified_cyanos,
+                                      color = Verified_cyanos)) +
+      geom_jitter(size=2) + 
+      theme_bw() + 
+      ggtitle('Jittered timeline of observed blooms in Lake Superior',
+              subtitle = 'Separated by whether or not cyanos was verified in a microscope')
+  }),
+  
   ##### PRISM climate driver summary figures #####
   
   tar_target(p4_prism_summary_timeseries, {

--- a/_targets.R
+++ b/_targets.R
@@ -12,6 +12,7 @@ tar_option_set(packages = c(
   'nhdplusTools',
   'prism',
   'raster',
+  'readxl',
   'sf',
   'tidyverse',
   'yaml'


### PR DESCRIPTION
Pull in and visualize the observed bloom data from Kait's automatically updating GD spreadsheet. This only adds it to the workflow (only those with Google Drive access will be able to run this). I am not committing any summaries about the file contents or showing the figures that were created because Kait is still working on appropriate attribution and permissions with the data.

This does add a map of observed bloom locations & a timeseries of observed blooms. Both are meh visuals for sake of time TBH.